### PR TITLE
Update 4600_export-utm-packages

### DIFF
--- a/build-steps.d/4600_export-utm-packages
+++ b/build-steps.d/4600_export-utm-packages
@@ -48,11 +48,8 @@ export_utm_packages() {
    $str_replace_tool "_ARCH_"   "${utm_arch}"   "${binary_image_utm_folder}/config.plist"
    $str_replace_tool "_TARGET_" "${utm_target}" "${binary_image_utm_folder}/config.plist"
 
-   # fill in correct filename for binary image raw file
-   $str_replace_tool "Whonix-Gateway-Xfce.raw" "${VMNAME}.raw" "${binary_image_utm_folder}/config.plist"
-
-   # fill in correct flavor name
-   $str_replace_tool "Whonix-Gateway-Xfce" "${VMNAME}" "${binary_image_utm_folder}/config.plist"
+   # fill in correct flavor for raw image filename and VM name as it appears on UTM.
+   $str_replace_tool "_FLAVOR_" "${VMNAME}.raw" "${binary_image_utm_folder}/config.plist"
 
    ## compress the utm folder into one archive respecting sparse (null) bytes
    ## dm-prepare-release also uses tar. Using similar options here.

--- a/build-steps.d/4600_export-utm-packages
+++ b/build-steps.d/4600_export-utm-packages
@@ -48,6 +48,12 @@ export_utm_packages() {
    $str_replace_tool "_ARCH_"   "${utm_arch}"   "${binary_image_utm_folder}/config.plist"
    $str_replace_tool "_TARGET_" "${utm_target}" "${binary_image_utm_folder}/config.plist"
 
+   # fill in correct filename for binary image raw file
+   $str_replace_tool "Whonix-Gateway-Xfce.raw" "${VMNAME}.raw" "${binary_image_utm_folder}/config.plist"
+
+   # fill in correct flavor name
+   $str_replace_tool "Whonix-Gateway-Xfce" "${VMNAME}" "${binary_image_utm_folder}/config.plist"
+
    ## compress the utm folder into one archive respecting sparse (null) bytes
    ## dm-prepare-release also uses tar. Using similar options here.
    tar \


### PR DESCRIPTION
The `plist` template has "Whonix-Gateway-Xfce" hard coded. This presents an issue when attempting to build Whonix-Gateway-CLI as the buildscript would create a raw image file with the filename `Whonix-Gateway-CLI.raw` while the the `config.plist`would point to a nonexistent `Whonix-Gateway-Xfce.raw`file. 

The same goes for the VM naming as it appears in UTM

This pull request changes...

## Changes

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.whonix.org/wiki/Terms_of_Service), [Privacy Policy](https://www.whonix.org/wiki/Privacy_Policy), [Cookie Policy](https://www.whonix.org/wiki/Cookie_Policy), [E-Sign Consent](https://www.whonix.org/wiki/E-Sign_Consent), [DMCA](https://www.whonix.org/wiki/DMCA), [Imprint](https://www.whonix.org/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
